### PR TITLE
PULSE-310: add status flag to document

### DIFF
--- a/pulse/broker/src/main/java/gov/ca/emsa/pulse/broker/dto/DocumentDTO.java
+++ b/pulse/broker/src/main/java/gov/ca/emsa/pulse/broker/dto/DocumentDTO.java
@@ -1,11 +1,14 @@
 package gov.ca.emsa.pulse.broker.dto;
 
 import gov.ca.emsa.pulse.broker.entity.DocumentEntity;
+import gov.ca.emsa.pulse.common.domain.QueryLocationStatus;
 
 public class DocumentDTO {
 	private long id;
 	private byte[] contents;
 	private Long patientLocationMapId;
+	private Long statusId;
+	private QueryLocationStatus status;
 	
 	//metadata
 	private String format;
@@ -26,6 +29,10 @@ public class DocumentDTO {
 	
 	public DocumentDTO(DocumentEntity entity) {
 		this.id = entity.getId();
+		this.statusId = entity.getStatusId();
+		if(entity.getStatus() != null) {
+			this.status = entity.getStatus().getStatus();
+		}
 		this.name = entity.getName();
 		this.format = entity.getFormat();
 		this.className = entity.getClassName();
@@ -141,5 +148,21 @@ public class DocumentDTO {
 
 	public void setDocumentUniqueId(String documentUniqueId) {
 		this.documentUniqueId = documentUniqueId;
+	}
+
+	public Long getStatusId() {
+		return statusId;
+	}
+
+	public void setStatusId(Long statusId) {
+		this.statusId = statusId;
+	}
+
+	public QueryLocationStatus getStatus() {
+		return status;
+	}
+
+	public void setStatus(QueryLocationStatus status) {
+		this.status = status;
 	}
 }

--- a/pulse/broker/src/main/java/gov/ca/emsa/pulse/broker/dto/DomainToDtoConverter.java
+++ b/pulse/broker/src/main/java/gov/ca/emsa/pulse/broker/dto/DomainToDtoConverter.java
@@ -120,6 +120,7 @@ public class DomainToDtoConverter {
 
 	public static DocumentDTO convert(Document domainObj) {
 		DocumentDTO result = new DocumentDTO();
+		result.setStatus(domainObj.getStatus());
 		result.setName(domainObj.getName());
 		result.setFormat(domainObj.getFormat());
 		result.setClassName(domainObj.getClassName());

--- a/pulse/broker/src/main/java/gov/ca/emsa/pulse/broker/dto/DtoToDomainConverter.java
+++ b/pulse/broker/src/main/java/gov/ca/emsa/pulse/broker/dto/DtoToDomainConverter.java
@@ -294,6 +294,7 @@ public class DtoToDomainConverter {
 	public static Document convert(DocumentDTO dtoObj) {
 		Document result = new Document();
 		result.setId(dtoObj.getId()+"");
+		result.setStatus(dtoObj.getStatus());
 		result.setName(dtoObj.getName());
 		result.setFormat(dtoObj.getFormat());
 		result.setCached(dtoObj.getContents() != null && dtoObj.getContents().length > 0);

--- a/pulse/broker/src/main/java/gov/ca/emsa/pulse/broker/entity/DocumentEntity.java
+++ b/pulse/broker/src/main/java/gov/ca/emsa/pulse/broker/entity/DocumentEntity.java
@@ -2,6 +2,7 @@ package gov.ca.emsa.pulse.broker.entity;
 
 import java.util.Date;
 
+import javax.persistence.Basic;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -63,6 +64,14 @@ public class DocumentEntity {
 	@OneToOne(optional = true, fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
 	@JoinColumn(name = "patient_location_map_id", unique=true, nullable = true, insertable=false, updatable= false)
 	private PatientLocationMapEntity patientLocationMap;
+	
+	@Column(name = "status_id")
+	private Long statusId;
+	
+	@Basic( optional = true )
+	@OneToOne(optional = true, fetch = FetchType.LAZY)
+	@JoinColumn(name = "status_id", unique=true, nullable = false, insertable=false, updatable= false)
+	private QueryLocationStatusEntity status;
 	
 	@Column( name = "creation_date", insertable = false, updatable = false)
 	private Date creationDate;
@@ -207,5 +216,21 @@ public class DocumentEntity {
 
 	public void setDocumentUniqueId(String documentUniqueId) {
 		this.documentUniqueId = documentUniqueId;
+	}
+
+	public Long getStatusId() {
+		return statusId;
+	}
+
+	public void setStatusId(Long statusId) {
+		this.statusId = statusId;
+	}
+
+	public QueryLocationStatusEntity getStatus() {
+		return status;
+	}
+
+	public void setStatus(QueryLocationStatusEntity status) {
+		this.status = status;
 	}
 }

--- a/pulse/broker/src/main/java/gov/ca/emsa/pulse/broker/manager/impl/DocumentManagerImpl.java
+++ b/pulse/broker/src/main/java/gov/ca/emsa/pulse/broker/manager/impl/DocumentManagerImpl.java
@@ -16,6 +16,7 @@ import gov.ca.emsa.pulse.broker.manager.AlternateCareFacilityManager;
 import gov.ca.emsa.pulse.broker.manager.DocumentManager;
 import gov.ca.emsa.pulse.broker.manager.PatientManager;
 import gov.ca.emsa.pulse.broker.saml.SAMLInput;
+import gov.ca.emsa.pulse.common.domain.QueryLocationStatus;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -95,6 +96,10 @@ public class DocumentManagerImpl implements DocumentManager {
 			if(adapter != null) {
 				logger.info("Starting query to endpoint with external id '" + endpointToQuery.getExternalId() + "' for document contents.");
 				try {
+					for(DocumentDTO doc : docsFromLocation) {
+						doc.setStatus(QueryLocationStatus.Active);
+						docDao.update(doc);
+					}
 					adapter.retrieveDocumentsContents(user, endpointToQuery, docsFromLocation, samlInput, dto);
 				} catch(Exception ex) {
 					logger.error("Exception thrown in adapter " + adapter.getClass(), ex);
@@ -108,6 +113,17 @@ public class DocumentManagerImpl implements DocumentManager {
 			//store the returned document contents
 			for(DocumentDTO doc : docsFromLocation) {
 				if(doc.getContents() != null && doc.getContents().length > 0) {
+					doc.setStatus(QueryLocationStatus.Successful);
+					docDao.update(doc);
+				}
+			}
+		} else {
+			for(DocumentDTO doc : docsFromLocation) {
+				if(doc.getContents() != null && doc.getContents().length > 0) {
+					doc.setStatus(QueryLocationStatus.Successful);
+					docDao.update(doc);
+				} else {
+					doc.setStatus(QueryLocationStatus.Failed);
 					docDao.update(doc);
 				}
 			}

--- a/pulse/common/src/main/java/gov/ca/emsa/pulse/common/domain/Document.java
+++ b/pulse/common/src/main/java/gov/ca/emsa/pulse/common/domain/Document.java
@@ -7,6 +7,7 @@ public class Document {
 	private Boolean cached;
 	private Long locationMapId;
 	private Patient patient;
+	private QueryLocationStatus status;
 	
 	//metadata
 	private String className;
@@ -113,6 +114,14 @@ public class Document {
 
 	public void setIdentifier(DocumentIdentifier identifier) {
 		this.identifier = identifier;
+	}
+
+	public QueryLocationStatus getStatus() {
+		return status;
+	}
+
+	public void setStatus(QueryLocationStatus status) {
+		this.status = status;
 	}
 	
 }


### PR DESCRIPTION
There was already a cached field to indicate if the document had been cached which was being populated correctly but I guess not used anywhere... I didn't remove that, but now there is a status field which will have one of the same statuses as queries do (NULL if they haven't tried to get it, Active if it is being fetched, Successful, or Failed)