### PR TITLE
change timestamp and soap signature config properties

### DIFF
--- a/pulse/broker/src/main/java/gov/ca/emsa/pulse/broker/adapter/service/EHealthQueryProducerServiceImpl.java
+++ b/pulse/broker/src/main/java/gov/ca/emsa/pulse/broker/adapter/service/EHealthQueryProducerServiceImpl.java
@@ -105,10 +105,10 @@ public class EHealthQueryProducerServiceImpl implements EHealthQueryProducerServ
 	@Autowired private SamlGenerator samlGenerator;
 	private Crypto crypto;
 	
-	@Value("${server.ssl.key-store-password}")
+	@Value("${soapKeystorePass}")
 	private String keystorepass;
 	
-	@Value("${server.ssl.keyAlias}")
+	@Value("${soapKeystoreAlias}")
 	private String keystorealias;
 	
 	@Value("${timeToLiveTimestamp}")

--- a/pulse/broker/src/main/resources/application.properties.template
+++ b/pulse/broker/src/main/resources/application.properties.template
@@ -59,6 +59,9 @@ endpoints.health.sensitive=false
 
 mtomMutltipartRequest
 
+soapKeystorePass=<insertSoapCertPassToSign>
+soapKeystoreAlias=<insertSoapCertKeystoreToSign>
+
 server.ssl.key-store: src/main/resources/keystore.p12
 server.ssl.key-store-password: <insert password>
 server.ssl.keyStoreType: PKCS12

--- a/pulse/broker/src/test/resources/application-test.properties.template
+++ b/pulse/broker/src/test/resources/application-test.properties.template
@@ -48,5 +48,8 @@ timeToLiveTimestamp=300
 
 mtomMutltipartRequest
 
+soapKeystorePass=<insertSoapCertPassToSign>
+soapKeystoreAlias=<insertSoapCertKeystoreToSign>
+
 #how often do we check the cache to clean up expired entries
 queryCacheCleanupMinutes=10


### PR DESCRIPTION
Signing the timestamp and the SOAP message used the same certificate that is attached to the SSL connection. In order to test where or not using a self-signed cert will work i need to make separate property for keystore alias and password 